### PR TITLE
Add DDEV configuration

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,10 @@
+name: cancheroo
+project_type: laravel
+docroot: public
+php_version: "8.1"
+webserver_type: nginx-fpm
+router_http_port: "80"
+router_https_port: "443"
+use_dns_when_possible: true
+xdebug_enabled: false
+composer_version: "2"

--- a/.ddev/docker-compose.db.yaml
+++ b/.ddev/docker-compose.db.yaml
@@ -1,0 +1,9 @@
+version: '3.6'
+services:
+  db:
+    container_name: ddev-${DDEV_SITENAME}-db
+    image: mariadb:10.6
+    restart: 'no'
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=db

--- a/.ddev/docker-compose.redis.yaml
+++ b/.ddev/docker-compose.redis.yaml
@@ -1,0 +1,8 @@
+version: '3.6'
+services:
+  redis:
+    container_name: ddev-${DDEV_SITENAME}-redis
+    image: redis:7-alpine
+    restart: 'no'
+    ports:
+      - "6379"


### PR DESCRIPTION
## Summary
- set up Laravel DDEV config with PHP 8.1
- add redis and db compose files for extra services

## Testing
- `sudo -u developer ddev start` *(fails: Unable to get Docker context: executable file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840be36b36883209ac2abd581178b9d