### PR TITLE
Ignore debug keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mobile/android/app/debug.keystore
+


### PR DESCRIPTION
## Summary
- ignore Android debug keystore

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf92e7a08320a623cb0efb06ccf0