### PR TITLE
Add API feature placeholders

### DIFF
--- a/backend/TASKS.md
+++ b/backend/TASKS.md
@@ -1,0 +1,65 @@
+# Backend tasks
+
+The existing `backend` directory is an empty Laravel skeleton. Use it to implement the API.
+
+## Setup
+- [ ] Install Composer dependencies (`composer install`)
+- [ ] Create a `.env` file and run `php artisan key:generate`
+- [ ] Configure database connection and run migrations
+
+## Features
+1. **Search and filters**
+   - [ ] Endpoint to search available fields filtered by sport, location, day/time and field type
+2. **Field information**
+   - [ ] Return photos, map location, real‑time schedule, price and amenities
+3. **Booking flow**
+   - [ ] Calendar with free slots
+   - [ ] Allow booking in advance or last minute
+   - [ ] Optional cost split between participants and instant confirmation
+4. **Payments**
+   - [ ] Integrate MercadoPago or similar
+   - [ ] Support cash payments and individual player payments
+5. **Reservation management**
+   - [ ] Reservation history
+   - [ ] Cancel, reschedule or modify
+   - [ ] Notifications for reminders, weather changes and cancellations
+6. **Players and teams**
+   - [ ] Create groups or teams
+   - [ ] Invite friends and confirm attendance
+7. **Ratings**
+   - [ ] Allow users to rate fields and clubs
+   - [ ] Store textual reviews
+8. **Loyalty program**
+   - [ ] Points/discounts for frequent bookings
+   - [ ] Promotions for low demand days
+9. **Tournaments/events**
+   - [ ] Allow users to sign up for tournaments and leagues
+10. **Club admin panel**
+    - [ ] Manage schedules, prices and availability
+    - [ ] Confirm offline payments
+    - [ ] Generate statistics and reports
+11. **Recurring reservations**
+    - [ ] Weekly automatic bookings for regular teams
+12. **Weather integration**
+    - [ ] Show rain forecast and send alerts if weather changes
+13. **Geolocation**
+    - [ ] Search by current location
+    - [ ] Provide routes via Google Maps or Waze
+14. **Chat/notifications**
+    - [ ] Basic chat or push notifications between players
+15. **Wait list**
+    - [ ] Allow players to join a wait list when a field is occupied and notify when free
+16. **Player ranking/gamification**
+    - [ ] Track attendance or fair play and compute league stats
+17. **Social login**
+    - [ ] Login with Google/Apple/Facebook and allow sharing results
+18. **Calendar integration**
+    - [ ] Sync bookings to Google Calendar or Apple Calendar
+19. **Extra rentals**
+    - [ ] Rent balls, bibs, referees, or other services
+20. **Smart notifications**
+    - [ ] Suggest available times or promotions based on past behaviour
+21. **Multi language and currency**
+    - [ ] API responses support multiple languages and currencies
+
+Add tests for any new functionality. Run `composer test` before committing.

--- a/backend/app/Http/Controllers/Api/AdminController.php
+++ b/backend/app/Http/Controllers/Api/AdminController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class AdminController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "AdminController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/BookingController.php
+++ b/backend/app/Http/Controllers/Api/BookingController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class BookingController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "BookingController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/CalendarController.php
+++ b/backend/app/Http/Controllers/Api/CalendarController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class CalendarController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "CalendarController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/ChatController.php
+++ b/backend/app/Http/Controllers/Api/ChatController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ChatController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "ChatController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class FieldController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "FieldController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/GeolocationController.php
+++ b/backend/app/Http/Controllers/Api/GeolocationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class GeolocationController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "GeolocationController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/LocalizationController.php
+++ b/backend/app/Http/Controllers/Api/LocalizationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LocalizationController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "LocalizationController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/LoyaltyController.php
+++ b/backend/app/Http/Controllers/Api/LoyaltyController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LoyaltyController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "LoyaltyController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/NotificationController.php
+++ b/backend/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "NotificationController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/PaymentController.php
+++ b/backend/app/Http/Controllers/Api/PaymentController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class PaymentController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "PaymentController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/RankingController.php
+++ b/backend/app/Http/Controllers/Api/RankingController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class RankingController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "RankingController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/RatingController.php
+++ b/backend/app/Http/Controllers/Api/RatingController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class RatingController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "RatingController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/RecurringController.php
+++ b/backend/app/Http/Controllers/Api/RecurringController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class RecurringController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "RecurringController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/RentalController.php
+++ b/backend/app/Http/Controllers/Api/RentalController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class RentalController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "RentalController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/ReservationController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ReservationController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "ReservationController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/SearchController.php
+++ b/backend/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "SearchController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/SocialLoginController.php
+++ b/backend/app/Http/Controllers/Api/SocialLoginController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class SocialLoginController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "SocialLoginController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/TeamController.php
+++ b/backend/app/Http/Controllers/Api/TeamController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TeamController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "TeamController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/TournamentController.php
+++ b/backend/app/Http/Controllers/Api/TournamentController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TournamentController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "TournamentController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/WaitlistController.php
+++ b/backend/app/Http/Controllers/Api/WaitlistController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class WaitlistController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "WaitlistController placeholder"]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/WeatherController.php
+++ b/backend/app/Http/Controllers/Api/WeatherController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class WeatherController extends Controller
+{
+    public function handle(Request $request)
+    {
+        return response()->json(["message" => "WeatherController placeholder"]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\SearchController;
+use App\Http\Controllers\Api\FieldController;
+use App\Http\Controllers\Api\BookingController;
+use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\ReservationController;
+use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\RatingController;
+use App\Http\Controllers\Api\LoyaltyController;
+use App\Http\Controllers\Api\TournamentController;
+use App\Http\Controllers\Api\AdminController;
+use App\Http\Controllers\Api\RecurringController;
+use App\Http\Controllers\Api\WeatherController;
+use App\Http\Controllers\Api\GeolocationController;
+use App\Http\Controllers\Api\ChatController;
+use App\Http\Controllers\Api\WaitlistController;
+use App\Http\Controllers\Api\RankingController;
+use App\Http\Controllers\Api\SocialLoginController;
+use App\Http\Controllers\Api\CalendarController;
+use App\Http\Controllers\Api\RentalController;
+use App\Http\Controllers\Api\NotificationController;
+use App\Http\Controllers\Api\LocalizationController;
+
+Route::get('search', [SearchController::class, 'handle']);
+Route::get('fields/{id}', [FieldController::class, 'handle']);
+Route::post('bookings', [BookingController::class, 'handle']);
+Route::post('payments', [PaymentController::class, 'handle']);
+Route::get('reservations', [ReservationController::class, 'handle']);
+Route::get('teams', [TeamController::class, 'handle']);
+Route::post('ratings', [RatingController::class, 'handle']);
+Route::get('loyalty', [LoyaltyController::class, 'handle']);
+Route::get('tournaments', [TournamentController::class, 'handle']);
+Route::get('admin', [AdminController::class, 'handle']);
+Route::post('recurring', [RecurringController::class, 'handle']);
+Route::get('weather', [WeatherController::class, 'handle']);
+Route::get('geolocation', [GeolocationController::class, 'handle']);
+Route::get('chat', [ChatController::class, 'handle']);
+Route::post('waitlist', [WaitlistController::class, 'handle']);
+Route::get('ranking', [RankingController::class, 'handle']);
+Route::post('social-login', [SocialLoginController::class, 'handle']);
+Route::get('calendar', [CalendarController::class, 'handle']);
+Route::post('rentals', [RentalController::class, 'handle']);
+Route::get('notifications', [NotificationController::class, 'handle']);
+Route::get('localization', [LocalizationController::class, 'handle']);

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -9,3 +9,5 @@ Route::get('/', function () {
 Route::get('/ping', function () {
     return 'pong';
 });
+
+Route::prefix('api')->group(__DIR__.'/api.php');

--- a/backend/tests/Feature/ApiRoutesTest.php
+++ b/backend/tests/Feature/ApiRoutesTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ApiRoutesTest extends TestCase
+{
+    public function test_search_route_returns_success(): void
+    {
+        $response = $this->get('/api/search');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder controllers for each backend task
- register new API routes via `api.php`
- link API routes from `web.php`
- add basic feature test for `/api/search`

## Testing
- `composer install --no-interaction`
- `php artisan key:generate`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6842fd2dd6208320b7eabd0e50c549f9